### PR TITLE
Setting WiFi.mode() to WIFI_AP after failed attempts at wifiConnect. …

### DIFF
--- a/ESP8266_DHT22_TempSensor.ino
+++ b/ESP8266_DHT22_TempSensor.ino
@@ -177,6 +177,7 @@ void wifiInit() {
     Serial.println("WiFi Connection failed, Starting AP...");
 
     // Start the access point
+    WiFi.mode(WIFI_AP);
     WiFi.softAP(apssid.c_str(), appass);
     ipaddr = WiFi.softAPIP().toString();
     Serial.println("AP:" + apssid + " Web config IP: http://" + WiFi.softAPIP().toString() + ":8080");
@@ -531,6 +532,9 @@ void loop() {
   if (now > next_network_check) {
     if (!networkOK())
       wifiConnect(ATTEMPTS);
+
+    if (!networkOK())
+      WiFi.mode(WIFI_AP);
 
     next_network_check = now + network_check_interval;
   }


### PR DESCRIPTION
…Seems to make softap much much more reliable. Docs seem to indicate that WiFi.mode(WIFI_STA) should preent ap from working at all. Strangely enough it worked for me a few times, just unreliably.